### PR TITLE
fix

### DIFF
--- a/ccvfi/arch/arch_utils/softsplat_torch.py
+++ b/ccvfi/arch/arch_utils/softsplat_torch.py
@@ -7,7 +7,6 @@
 import torch
 
 ##########################################################
-device = "cuda" if torch.cuda.is_available() else "cpu"
 
 grid_cache = {}
 batch_cache = {}

--- a/ccvfi/arch/arch_utils/warplayer.py
+++ b/ccvfi/arch/arch_utils/warplayer.py
@@ -1,7 +1,6 @@
 # type: ignore
 import torch
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 backwarp_tenGrid = {}
 
 
@@ -9,16 +8,16 @@ def warp(tenInput, tenFlow):
     k = (str(tenFlow.device), str(tenFlow.size()))
     if k not in backwarp_tenGrid:
         tenHorizontal = (
-            torch.linspace(-1.0, 1.0, tenFlow.shape[3], device=device)
+            torch.linspace(-1.0, 1.0, tenFlow.shape[3], device=tenFlow.device)
             .view(1, 1, 1, tenFlow.shape[3])
             .expand(tenFlow.shape[0], -1, tenFlow.shape[2], -1)
         )
         tenVertical = (
-            torch.linspace(-1.0, 1.0, tenFlow.shape[2], device=device)
+            torch.linspace(-1.0, 1.0, tenFlow.shape[2], device=tenFlow.device)
             .view(1, 1, tenFlow.shape[2], 1)
             .expand(tenFlow.shape[0], -1, -1, tenFlow.shape[3])
         )
-        backwarp_tenGrid[k] = torch.cat([tenHorizontal, tenVertical], 1).to(device)
+        backwarp_tenGrid[k] = torch.cat([tenHorizontal, tenVertical], 1).to(tenFlow.device)
 
     tenFlow = torch.cat(
         [

--- a/ccvfi/arch/drba_arch.py
+++ b/ccvfi/arch/drba_arch.py
@@ -8,8 +8,6 @@ from ccvfi.arch import ARCH_REGISTRY
 from ccvfi.arch.arch_utils.warplayer import warp
 from ccvfi.type import ArchType
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
 
 @ARCH_REGISTRY.register(name=ArchType.DRBA)
 class DRBA(nn.Module):

--- a/ccvfi/arch/ifnet_arch.py
+++ b/ccvfi/arch/ifnet_arch.py
@@ -8,7 +8,7 @@ from ccvfi.arch.arch_utils.warplayer import warp
 from ccvfi.type import ArchType
 
 
-@ARCH_REGISTRY.register(name=ArchType.IFNet)
+@ARCH_REGISTRY.register(name=ArchType.IFNET)
 class IFNet(nn.Module):
     def __init__(self):
         super(IFNet, self).__init__()

--- a/ccvfi/arch/ifnet_arch.py
+++ b/ccvfi/arch/ifnet_arch.py
@@ -7,8 +7,6 @@ from ccvfi.arch import ARCH_REGISTRY
 from ccvfi.arch.arch_utils.warplayer import warp
 from ccvfi.type import ArchType
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
 
 @ARCH_REGISTRY.register(name=ArchType.IFNet)
 class IFNet(nn.Module):

--- a/ccvfi/auto/model.py
+++ b/ccvfi/auto/model.py
@@ -26,9 +26,6 @@ class AutoModel:
         :param fp16: use fp16 precision or not
         :param compile: use torch.compile or not
         :param compile_backend: backend of torch.compile
-        :param tile: tile size for tile inference, tile[0] is width, tile[1] is height, None for disable
-        :param tile_pad: The padding size for each tile
-        :param pad_img: The size for the padded image, pad[0] is width, pad[1] is height, None for auto calculate
         :param model_dir: The path to cache the downloaded model. Should be a full path. If None, use default cache path.
         :param gh_proxy: The proxy for downloading from github release. Example: https://github.abskoop.workers.dev/
         :return:
@@ -63,9 +60,6 @@ class AutoModel:
         :param fp16: use fp16 precision or not
         :param compile: use torch.compile or not
         :param compile_backend: backend of torch.compile
-        :param tile: tile size for tile inference, tile[0] is width, tile[1] is height, None for disable
-        :param tile_pad: The padding size for each tile
-        :param pad_img: The size for the padded image, pad[0] is width, pad[1] is height, None for auto calculate
         :param model_dir: The path to cache the downloaded model. Should be a full path. If None, use default cache path.
         :param gh_proxy: The proxy for downloading from github release. Example: https://github.abskoop.workers.dev/
         :return:

--- a/ccvfi/config/ifnet_config.py
+++ b/ccvfi/config/ifnet_config.py
@@ -5,7 +5,7 @@ from ccvfi.type import ArchType, BaseConfig, ConfigType, ModelType
 
 
 class IFNetConfig(BaseConfig):
-    arch: Union[ArchType, str] = ArchType.IFNet
+    arch: Union[ArchType, str] = ArchType.IFNET
     model: Union[ModelType, str] = ModelType.IFNet
 
 

--- a/ccvfi/model/drba_model.py
+++ b/ccvfi/model/drba_model.py
@@ -1,8 +1,10 @@
-# type: ignore
-from typing import Any, Union
+from typing import Any, List, Union
 
+import cv2
+import numpy as np
 import torch
 import torch.nn.functional as F
+from torchvision import transforms
 
 from ccvfi.arch import DRBA
 from ccvfi.model import MODEL_REGISTRY, VFIBaseModel
@@ -26,7 +28,7 @@ class DRBAModel(VFIBaseModel):
 
         model = DRBA(support_cupy=HAS_CUDA)
 
-        def _convert(param) -> Any:
+        def _convert(param: Any) -> Any:
             return {k.replace("module.", ""): v for k, v in param.items() if "module." in k}
 
         model.load_state_dict(_convert(state_dict), strict=False)
@@ -36,7 +38,7 @@ class DRBAModel(VFIBaseModel):
     @torch.inference_mode()  # type: ignore
     def inference(
         self,
-        Inputs: torch.Tensor,
+        imgs: torch.Tensor,
         minus_t: list[float],
         zero_t: list[float],
         plus_t: list[float],
@@ -48,7 +50,7 @@ class DRBAModel(VFIBaseModel):
         """
         Inference with the model
 
-        :param Inputs: The input frames (B, 3, C, H, W)
+        :param imgs: The input frames (B, 3, C, H, W)
         :param minus_t: Timestep between -1 and 0 (I0 and I1)
         :param zero_t: Timestep of 0, if not empty, preserve I1 (I1)
         :param plus_t: Timestep between 0 and 1 (I1 and I2)
@@ -68,10 +70,10 @@ class DRBAModel(VFIBaseModel):
                 _w += 1
             return F.interpolate(img, size=(int(_h), int(_w)), mode="bilinear", align_corners=False)
 
-        def _de_resize(img, ori_h, ori_w) -> torch.Tensor:
+        def _de_resize(img: Any, ori_h: int, ori_w: int) -> torch.Tensor:
             return F.interpolate(img, size=(int(ori_h), int(ori_w)), mode="bilinear", align_corners=False)
 
-        I0, I1, I2 = Inputs[:, 0], Inputs[:, 1], Inputs[:, 2]
+        I0, I1, I2 = imgs[:, 0], imgs[:, 1], imgs[:, 2]
         _, _, h, w = I0.shape
         I0 = _resize(I0, scale).unsqueeze(0)
         I1 = _resize(I1, scale).unsqueeze(0)
@@ -84,3 +86,36 @@ class DRBAModel(VFIBaseModel):
         results = tuple(_de_resize(result, h, w) for result in results)
 
         return results, reuse
+
+    @torch.inference_mode()  # type: ignore
+    def inference_image_list(self, img_list: List[np.ndarray]) -> List[np.ndarray]:
+        """
+        Inference numpy image list with the model
+
+        :param img_list: 3 input frames (img0, img1, img2)
+
+        :return: 5 output frames (img0, img0_1, img1, img1_2, img2)
+        """
+        if len(img_list) != 3:
+            raise ValueError("DRBA img_list must contain 3 images")
+
+        img_list_tensor = []
+        for img in img_list:
+            img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+            img_tensor = transforms.ToTensor()(img).unsqueeze(0).to(self.device)
+            img_list_tensor.append(img_tensor)
+
+        inp = torch.stack(img_list_tensor, dim=1)
+
+        results, _ = self.inference(inp, [-1, -0.5], [0], [0.5, 1], False, False, 1.0, None)
+
+        ### 自己实现一下，这里DRBA输出的啥玩意，打断点看怎么还是个tuple，搞成张量
+        results_list = []
+        for i in range(results.shape[1]):
+            img = results[0, i, :, :, :]
+            img = img.permute(1, 2, 0).cpu().numpy()
+            img = (img * 255).clip(0, 255).astype("uint8")
+            img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
+            results_list.append(img)
+
+        return results_list

--- a/ccvfi/model/drba_model.py
+++ b/ccvfi/model/drba_model.py
@@ -26,14 +26,12 @@ class DRBAModel(VFIBaseModel):
 
         model = DRBA(support_cupy=HAS_CUDA)
 
-        model.load_state_dict(self.convert(state_dict), strict=False)
-        model.eval().to(self.device)
-        if self.fp16:
-            model = model.half()
-        return model
+        def _convert(param) -> Any:
+            return {k.replace("module.", ""): v for k, v in param.items() if "module." in k}
 
-    def convert(self, param) -> Any:
-        return {k.replace("module.", ""): v for k, v in param.items() if "module." in k}
+        model.load_state_dict(_convert(state_dict), strict=False)
+        model.eval().to(self.device)
+        return model
 
     @torch.inference_mode()  # type: ignore
     def inference(

--- a/ccvfi/model/ifnet_model.py
+++ b/ccvfi/model/ifnet_model.py
@@ -17,14 +17,12 @@ class IFNetModel(VFIBaseModel):
 
         model = IFNet()
 
-        model.load_state_dict(self.convert(state_dict), strict=False)
-        model.eval().to(self.device)
-        if self.fp16:
-            model = model.half()
-        return model
+        def _convert(param) -> Any:
+            return {k.replace("module.", ""): v for k, v in param.items() if "module." in k}
 
-    def convert(self, param) -> Any:
-        return {k.replace("module.", ""): v for k, v in param.items() if "module." in k}
+        model.load_state_dict(_convert(state_dict), strict=False)
+        model.eval().to(self.device)
+        return model
 
     @torch.inference_mode()  # type: ignore
     def inference(self, Inputs: torch.Tensor, timestep: float, scale: float) -> torch.Tensor:

--- a/ccvfi/model/ifnet_model.py
+++ b/ccvfi/model/ifnet_model.py
@@ -1,8 +1,10 @@
-# type: ignore
-from typing import Any
+from typing import Any, List
 
+import cv2
+import numpy as np
 import torch
 import torch.nn.functional as F
+from torchvision import transforms
 
 from ccvfi.arch import IFNet
 from ccvfi.model import MODEL_REGISTRY
@@ -17,7 +19,7 @@ class IFNetModel(VFIBaseModel):
 
         model = IFNet()
 
-        def _convert(param) -> Any:
+        def _convert(param: Any) -> Any:
             return {k.replace("module.", ""): v for k, v in param.items() if "module." in k}
 
         model.load_state_dict(_convert(state_dict), strict=False)
@@ -25,11 +27,11 @@ class IFNetModel(VFIBaseModel):
         return model
 
     @torch.inference_mode()  # type: ignore
-    def inference(self, Inputs: torch.Tensor, timestep: float, scale: float) -> torch.Tensor:
+    def inference(self, imgs: torch.Tensor, timestep: float, scale: float) -> torch.Tensor:
         """
         Inference with the model
 
-        :param Inputs: The input frames (B, 2, C, H, W)
+        :param imgs: The input frames (B, 2, C, H, W)
         :param timestep: Timestep between 0 and 1 (img0 and img1)
         :param scale: Flow scale.
 
@@ -44,10 +46,10 @@ class IFNetModel(VFIBaseModel):
                 _w += 1
             return F.interpolate(img, size=(int(_h), int(_w)), mode="bilinear", align_corners=False)
 
-        def _de_resize(img, ori_h, ori_w) -> torch.Tensor:
+        def _de_resize(img: Any, ori_h: int, ori_w: int) -> torch.Tensor:
             return F.interpolate(img, size=(int(ori_h), int(ori_w)), mode="bilinear", align_corners=False)
 
-        I0, I1 = Inputs[:, 0], Inputs[:, 1]
+        I0, I1 = imgs[:, 0], imgs[:, 1]
         _, _, h, w = I0.shape
         I0 = _resize(I0, scale)
         I1 = _resize(I1, scale)
@@ -60,3 +62,36 @@ class IFNetModel(VFIBaseModel):
         result = _de_resize(result, h, w)
 
         return result
+
+    @torch.inference_mode()  # type: ignore
+    def inference_image_list(self, img_list: List[np.ndarray]) -> List[np.ndarray]:
+        """
+        Inference numpy image list with the model
+
+        :param img_list: 2 input frames (img0, img1)
+
+        :return: 1 output frames (img0_1)
+        """
+        if len(img_list) != 2:
+            raise ValueError("IFNet img_list must contain 2 images")
+
+        img_list_tensor = []
+        for img in img_list:
+            img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+            img_tensor = transforms.ToTensor()(img).unsqueeze(0).to(self.device)
+            img_list_tensor.append(img_tensor)
+
+        inp = torch.stack(img_list_tensor, dim=1)
+
+        out = self.inference(inp, timestep=0.5, scale=1.0)
+
+        # Convert to numpy image list
+        results_list = []
+
+        img = out.squeeze(0).permute(1, 2, 0).cpu().numpy()
+        img = (img * 255).clip(0, 255).astype("uint8")
+        img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
+
+        results_list.append(img)
+
+        return results_list

--- a/ccvfi/model/vfi_base_model.py
+++ b/ccvfi/model/vfi_base_model.py
@@ -1,5 +1,6 @@
-from typing import Any
+from typing import Any, List
 
+import numpy as np
 import torch
 
 from ccvfi.cache_models import load_file_from_url
@@ -32,8 +33,11 @@ class VFIBaseModel(BaseModelInterface):
 
     @torch.inference_mode()  # type: ignore
     def inference(self, *args, **kwargs) -> torch.Tensor:
-        # cfg: BaseConfig = self.config
-        return self.model(*args, **kwargs)
+        raise NotImplementedError
+
+    @torch.inference_mode()  # type: ignore
+    def inference_image_list(self, img_list: List[np.ndarray]) -> List[np.ndarray]:
+        raise NotImplementedError
 
     @torch.inference_mode()  # type: ignore
     def inference_video(

--- a/ccvfi/type/arch.py
+++ b/ccvfi/type/arch.py
@@ -5,5 +5,5 @@ from enum import Enum
 class ArchType(str, Enum):
     # ------------------------------------- Video Frame Interpolation ----------------------------------------------
 
-    IFNet = "IFNet"
+    IFNET = "IFNET"
     DRBA = "DRBA"

--- a/ccvfi/type/base_model.py
+++ b/ccvfi/type/base_model.py
@@ -79,5 +79,12 @@ class BaseModelInterface(ABC):
     def inference(self, *args: Any, **kwargs: Any) -> torch.Tensor:
         raise NotImplementedError
 
+    @torch.inference_mode()  # type: ignore
+    def inference_video(self, *args: Any, **kwargs: Any) -> Any:
+        """
+        Inference the video with the model, the clip should be a vapoursynth clip
+        """
+        raise NotImplementedError
+
     def __call__(self, *args: Any, **kwargs: Any) -> torch.Tensor:
         return self.inference(*args)

--- a/ccvfi/type/base_model.py
+++ b/ccvfi/type/base_model.py
@@ -2,7 +2,6 @@ import sys
 from abc import ABC, abstractmethod
 from typing import Any, Optional
 
-import numpy as np
 import torch
 
 from ccvfi.util.device import DEFAULT_DEVICE
@@ -77,8 +76,8 @@ class BaseModelInterface(ABC):
 
     @abstractmethod
     @torch.inference_mode()  # type: ignore
-    def inference(self, *args: Any) -> np.ndarray:
+    def inference(self, *args: Any, **kwargs: Any) -> torch.Tensor:
         raise NotImplementedError
 
-    def __call__(self, *args: Any) -> np.ndarray:
+    def __call__(self, *args: Any, **kwargs: Any) -> torch.Tensor:
         return self.inference(*args)

--- a/tests/test_drba.py
+++ b/tests/test_drba.py
@@ -31,6 +31,6 @@ class Test_DRBA:
 
             for i in range(len(Outputs)):
                 out = (Outputs[i].squeeze(0).permute(1, 2, 0).cpu().numpy() * 255).astype(np.uint8)
-                cv2.imwrite(str(ASSETS_PATH / f"test_out_{i}.jpg"), out)
+                cv2.imwrite(str(ASSETS_PATH / f"test_{k}_out_{i}.jpg"), out)
 
                 assert calculate_image_similarity(eval_imgs[i], out)

--- a/tests/test_ifnet.py
+++ b/tests/test_ifnet.py
@@ -1,6 +1,4 @@
 import cv2
-import numpy as np
-import torch
 
 from ccvfi import AutoConfig, AutoModel, BaseConfig, ConfigType
 from ccvfi.model import VFIBaseModel
@@ -10,7 +8,7 @@ from .util import ASSETS_PATH, calculate_image_similarity, get_device, load_eval
 
 class Test_IFNet:
     def test_official(self) -> None:
-        img0, img1, img2 = load_images()
+        img0, img1, _ = load_images()
         eval_img = load_eval_image()
 
         for k in [ConfigType.IFNet_v426_heavy]:
@@ -19,15 +17,9 @@ class Test_IFNet:
             model: VFIBaseModel = AutoModel.from_config(config=cfg, fp16=False, device=get_device())
             print(model.device)
 
-            I0 = torch.from_numpy(img0).permute(2, 0, 1).unsqueeze(0).to(model.device) / 255.0
-            I1 = torch.from_numpy(img1).permute(2, 0, 1).unsqueeze(0).to(model.device) / 255.0
-            I0 = I0.unsqueeze(0)
-            I1 = I1.unsqueeze(0)
-            inp = torch.cat([I0, I1], dim=1)
+            out = model.inference_image_list(img_list=[img0, img1])
 
-            out = model.inference(inp, timestep=0.5, scale=1.0)
-            imgOut = (out.squeeze(0).permute(1, 2, 0).cpu().numpy() * 255).astype(np.uint8)
-
-            cv2.imwrite(str(ASSETS_PATH / "test_out.jpg"), imgOut)
-
-            assert calculate_image_similarity(eval_img, imgOut)
+            assert len(out) == 1
+            for img in out:
+                cv2.imwrite(str(ASSETS_PATH / f"test_{k}_out.jpg"), img)
+                assert calculate_image_similarity(eval_img, img)

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,6 +1,7 @@
 import math
 import os
 from pathlib import Path
+from typing import List
 
 import cv2
 import numpy as np
@@ -30,7 +31,7 @@ def get_device() -> torch.device:
     return DEFAULT_DEVICE
 
 
-def load_images() -> tuple[np.ndarray, ...]:
+def load_images() -> List[np.ndarray]:
     img0 = cv2.imdecode(np.fromfile(str(TEST_IMG_PATH0), dtype=np.uint8), cv2.IMREAD_COLOR)
     img1 = cv2.imdecode(np.fromfile(str(TEST_IMG_PATH1), dtype=np.uint8), cv2.IMREAD_COLOR)
     img2 = cv2.imdecode(np.fromfile(str(TEST_IMG_PATH2), dtype=np.uint8), cv2.IMREAD_COLOR)
@@ -38,10 +39,10 @@ def load_images() -> tuple[np.ndarray, ...]:
     img1 = cv2.resize(img1, (960, 540))
     img2 = cv2.resize(img2, (960, 540))
 
-    return img0, img1, img2
+    return [img0, img1, img2]
 
 
-def load_eval_images() -> tuple[np.ndarray, ...]:
+def load_eval_images() -> List[np.ndarray]:
     img0 = cv2.imdecode(np.fromfile(str(EVAL_IMG_PATH0), dtype=np.uint8), cv2.IMREAD_COLOR)
     img1 = cv2.imdecode(np.fromfile(str(EVAL_IMG_PATH1), dtype=np.uint8), cv2.IMREAD_COLOR)
     img2 = cv2.imdecode(np.fromfile(str(EVAL_IMG_PATH2), dtype=np.uint8), cv2.IMREAD_COLOR)
@@ -52,7 +53,7 @@ def load_eval_images() -> tuple[np.ndarray, ...]:
     img2 = cv2.resize(img2, (960, 540))
     img3 = cv2.resize(img3, (960, 540))
     img4 = cv2.resize(img4, (960, 540))
-    return img0, img1, img2, img3, img4
+    return [img0, img1, img2, img3, img4]
 
 
 def load_eval_image() -> np.ndarray:


### PR DESCRIPTION
1.把DRBA输出对齐下，怎么现在又是tuple又是list又是套了啥
2.把vs里面mapper 转场等和vs无关的东西抽走，别放在里面，放在utils下也好新建个包也好，vs下的东西设置了跳过静态检查 ci测试也不会测

## Summary by Sourcery

Add support for inference of image lists using `IFNet` and `DRBA` models.

New Features:
- Added `inference_image_list` method to the `VFIBaseModel` class and its subclasses to enable inference on a list of NumPy image arrays, returning a list of processed images.
- Added `inference_image_list` tests for `IFNet` and `DRBA` models using example image lists and verifying the output against expected results by calculating image similarity using SSIM.