### PR TITLE
rename rife

### DIFF
--- a/ccvfi/config/__init__.py
+++ b/ccvfi/config/__init__.py
@@ -2,5 +2,5 @@ from ccvfi.util.registry import RegistryConfigInstance
 
 CONFIG_REGISTRY: RegistryConfigInstance = RegistryConfigInstance("CONFIG")
 
-from ccvfi.config.ifnet_config import IFNetConfig  # noqa
+from ccvfi.config.rife_config import RIFEConfig  # noqa
 from ccvfi.config.drba_config import DRBAConfig  # noqa

--- a/ccvfi/config/rife_config.py
+++ b/ccvfi/config/rife_config.py
@@ -4,19 +4,19 @@ from ccvfi.config import CONFIG_REGISTRY
 from ccvfi.type import ArchType, BaseConfig, ConfigType, ModelType
 
 
-class IFNetConfig(BaseConfig):
+class RIFEConfig(BaseConfig):
     arch: Union[ArchType, str] = ArchType.IFNET
-    model: Union[ModelType, str] = ModelType.IFNet
+    model: Union[ModelType, str] = ModelType.RIFE
 
 
-IFNetConfigs = [
-    IFNetConfig(
-        name=ConfigType.IFNet_v426_heavy,
+RIFEConfigs = [
+    RIFEConfig(
+        name=ConfigType.RIFE_IFNet_v426_heavy,
         url="https://github.com/routineLife1/ccvfi/releases/download/weights/IFNet_v426_heavy.pkl",
         hash="4cc518e172156ad6207b9c7a43364f518832d83a4325d484240493a9e2980537",
         in_frame_count=2,
     )
 ]
 
-for cfg in IFNetConfigs:
+for cfg in RIFEConfigs:
     CONFIG_REGISTRY.register(cfg)

--- a/ccvfi/model/__init__.py
+++ b/ccvfi/model/__init__.py
@@ -3,5 +3,5 @@ from ccvfi.util.registry import Registry
 MODEL_REGISTRY: Registry = Registry("MODEL")
 
 from ccvfi.model.vfi_base_model import VFIBaseModel  # noqa
-from ccvfi.model.ifnet_model import IFNetModel  # noqa
+from ccvfi.model.rife_model import RIFEModel  # noqa
 from ccvfi.model.drba_model import DRBAModel  # noqa

--- a/ccvfi/model/rife_model.py
+++ b/ccvfi/model/rife_model.py
@@ -12,8 +12,8 @@ from ccvfi.type import ModelType
 from ccvfi.util.misc import de_resize, resize
 
 
-@MODEL_REGISTRY.register(name=ModelType.IFNet)
-class IFNetModel(VFIBaseModel):
+@MODEL_REGISTRY.register(name=ModelType.RIFE)
+class RIFEModel(VFIBaseModel):
     def load_model(self) -> Any:
         state_dict = self.get_state_dict()
 

--- a/ccvfi/type/config.py
+++ b/ccvfi/type/config.py
@@ -1,13 +1,13 @@
 from enum import Enum
 
 
-# Enum for config type, {ModelType.model}_{config_name}_{scale}x.pth
+# Enum for config type, {ModelType.model}_{config_name}.pth
 # For the Auxiliary Network, {ModelType.model}_{config_name}.pth
 class ConfigType(str, Enum):
     # ------------------------------------- Video Frame Interpolation ----------------------------------------------
 
-    # RIFE (IFNet)
-    IFNet_v426_heavy = "IFNet_v426_heavy.pkl"
+    # RIFE
+    RIFE_IFNet_v426_heavy = "RIFE_IFNet_v426_heavy.pkl"
 
     # DRBA
     DRBA_IFNet = "DRBA_IFNet.pkl"

--- a/ccvfi/type/model.py
+++ b/ccvfi/type/model.py
@@ -5,5 +5,5 @@ from enum import Enum
 class ModelType(str, Enum):
     # ------------------------------------- Video Frame Interpolation ----------------------------------------------
 
-    IFNet = "IFNet"
+    RIFE = "RIFE"
     DRBA = "DRBA"

--- a/tests/test_auto_class.py
+++ b/tests/test_auto_class.py
@@ -1,15 +1,15 @@
 from typing import Any
 
 from ccvfi import AutoConfig, AutoModel
-from ccvfi.config import IFNetConfig
-from ccvfi.model import IFNetModel
+from ccvfi.config import RIFEConfig
+from ccvfi.model import RIFEModel
 
 
 def test_auto_class_register() -> None:
     cfg_name = "TESTCONFIG.pth"
     model_name = "TESTMODEL"
 
-    cfg = IFNetConfig(
+    cfg = RIFEConfig(
         name=cfg_name,
         model=model_name,
         url="https://github.com/routineLife1/ccvfi/releases/download/weights/IFNet_v426_heavy.pkl",
@@ -20,7 +20,7 @@ def test_auto_class_register() -> None:
     AutoConfig.register(cfg)
 
     @AutoModel.register(name=model_name)
-    class TESTMODEL(IFNetModel):
+    class TESTMODEL(RIFEModel):
         def load_model(self) -> Any:
             return None
 

--- a/tests/test_cache_models.py
+++ b/tests/test_cache_models.py
@@ -3,17 +3,17 @@ from ccvfi.cache_models import load_file_from_url
 
 
 def test_cache_models() -> None:
-    load_file_from_url(CONFIG_REGISTRY.get(ConfigType.IFNet_v426_heavy))
+    load_file_from_url(CONFIG_REGISTRY.get(ConfigType.RIFE_IFNet_v426_heavy))
 
 
 def test_cache_models_with_gh_proxy() -> None:
     load_file_from_url(
-        config=CONFIG_REGISTRY.get(ConfigType.IFNet_v426_heavy),
+        config=CONFIG_REGISTRY.get(ConfigType.RIFE_IFNet_v426_heavy),
         force_download=True,
         gh_proxy="https://github.abskoop.workers.dev/",
     )
     load_file_from_url(
-        config=CONFIG_REGISTRY.get(ConfigType.IFNet_v426_heavy),
+        config=CONFIG_REGISTRY.get(ConfigType.RIFE_IFNet_v426_heavy),
         force_download=True,
         gh_proxy="https://github.abskoop.workers.dev",
     )

--- a/tests/test_rife.py
+++ b/tests/test_rife.py
@@ -6,12 +6,12 @@ from ccvfi.model import VFIBaseModel
 from .util import ASSETS_PATH, calculate_image_similarity, get_device, load_eval_image, load_images
 
 
-class Test_IFNet:
+class Test_RIFE:
     def test_official(self) -> None:
         img0, img1, _ = load_images()
         eval_img = load_eval_image()
 
-        for k in [ConfigType.IFNet_v426_heavy]:
+        for k in [ConfigType.RIFE_IFNet_v426_heavy]:
             print(f"Testing {k}")
             cfg: BaseConfig = AutoConfig.from_pretrained(k)
             model: VFIBaseModel = AutoModel.from_config(config=cfg, fp16=False, device=get_device())

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -103,24 +103,29 @@ def test_ssim_matlab() -> None:
     assert 0.0 <= ssim_value.item() <= 1.0
 
 
-def test_check_scene() -> None:
-    # 创建符合要求的输入张量 (N, C, H, W)
-    x1 = torch.randn(1, 1, 3, 64, 64)  # 批次大小 1，通道数 3，高度 64，宽度 64
-    x2 = torch.randn(1, 1, 3, 64, 64)
+class Test_Check_Scene:
+    def test_5d(self) -> None:
+        x1 = torch.randn(1, 1, 3, 64, 64)
+        x2 = torch.randn(1, 1, 3, 64, 64)
 
-    # 测试 enable_scdet 为 False 的情况
-    result = check_scene(x1, x2, enable_scdet=False, scdet_threshold=0.5)
-    assert result is False  # 当 enable_scdet 为 False 时，应返回 False
+        # 测试 enable_scdet 为 False 的情况
+        result = check_scene(x1, x2, enable_scdet=False, scdet_threshold=0.5)
+        assert result is False  # 当 enable_scdet 为 False 时，应返回 False
 
-    # 测试 enable_scdet 为 True 的情况
-    result = check_scene(x1, x2, enable_scdet=True, scdet_threshold=0.5)
-    assert isinstance(result, bool)
+        # 测试 enable_scdet 为 True 的情况
+        result = check_scene(x1, x2, enable_scdet=True, scdet_threshold=0.5)
+        assert isinstance(result, bool)
 
-    # 测试输入张量维度不正确的情况
-    with pytest.raises(ValueError):
-        x1_invalid = torch.randn(1, 3, 64, 64)  # 缺少批次维度
-        check_scene(x1_invalid, x2, enable_scdet=True, scdet_threshold=0.5)
+    def test_4d(self) -> None:
+        x1 = torch.randn(1, 3, 64, 64)
+        x2 = torch.randn(1, 3, 64, 64)
 
-    with pytest.raises(ValueError):
-        x2_invalid = torch.randn(1, 1, 64, 64)  # 缺少通道维度
-        check_scene(x1, x2_invalid, enable_scdet=True, scdet_threshold=0.5)
+        result = check_scene(x1, x2, enable_scdet=True, scdet_threshold=0.5)
+        assert isinstance(result, bool)
+
+    def test_3d(self) -> None:
+        x1 = torch.randn(3, 64, 64)
+        x2 = torch.randn(3, 64, 64)
+
+        result = check_scene(x1, x2, enable_scdet=True, scdet_threshold=0.5)
+        assert isinstance(result, bool)


### PR DESCRIPTION
## Summary by Sourcery

Rename IFNet to RIFE.

Build:
- Renamed IFNet config files to RIFE.

Tests:
- Updated tests to use RIFE instead of IFNet.

Chores:
- Renamed IFNet model files to RIFE.
- Updated model registry and config type enum to reflect the name change.